### PR TITLE
removed unneeded rm in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -26,6 +26,4 @@ curl -# $ZIP_URL > $ZIP_FILE
 echo "unzipping.."
 unzip $ZIP_FILE
 popd
-rm -f ./latest
-ln -s $REVISION/chrome-linux/ ./latest
-
+ln -Tfs $REVISION/chrome-linux/ ./latest


### PR DESCRIPTION
ln with '-f' flag removes existing destination files, so there is no reason to use 'rm -f'
