### PR TITLE
Update scripts to provide Developer Sandbox automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+latest
+user-data-dir

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,15 @@
 
 BASEDIR=$(dirname $0)
 
+export CHROME_DEVEL_SANDBOX=$BASEDIR/latest/chrome_sandbox
+
+# Uncomment these lines to get rid of API Keys missing warning
+#export GOOGLE_API_KEY="no"
+#export GOOGLE_DEFAULT_CLIENT_ID="no"
+#export GOOGLE_DEFAULT_CLIENT_SECRET="no"
+
+# Use this if you want separate profile location
 $BASEDIR/latest/chrome --user-data-dir="$BASEDIR/user-data-dir" $* &> /dev/null &
+
+# Use this if you want to use standard profile location
+# $BASEDIR/latest/chrome-wrapper $* &> /dev/null &

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-BASEDIR=$(dirname $0)
+BASEDIR=$(dirname $(realpath $0))
 
 export CHROME_DEVEL_SANDBOX=$BASEDIR/latest/chrome_sandbox
 

--- a/update.sh
+++ b/update.sh
@@ -29,3 +29,4 @@ popd
 rm -f ./latest
 ln -s $REVISION/chrome-linux/ ./latest
 
+./update_wrapper.sh

--- a/update_wrapper.sh
+++ b/update_wrapper.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Chrome Wrapper Update"
+
+sudo chown root:root latest/chrome_sandbox
+sudo chmod 4755 latest/chrome_sandbox


### PR DESCRIPTION
- Added Sandbox env variable export and setting the correct permissions in update_wrapper.sh
- GIT Ignoring common directories (latest, user-data-dir)
- Resolving correctly BASEDIR when the run.sh is symlinked into another directory
- Added optional lines to uncomment, to remove API keys missing warning and form of command to run chromium on standard user profile
