### PR TITLE
Add support for a fixed revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # chromium-latest-linux
 Scripts to download and run the latest Linux build of Chromium.
+
+## Usage
+
+Download and updates the latest build of Chromium
+
+    $ ./update-and-run.sh
+
+Download a specific revision
+
+    $ export REVISION=492595
+    $ ./update-and-run.sh

--- a/update.sh
+++ b/update.sh
@@ -4,9 +4,13 @@ cd $(dirname $0)
 
 LASTCHANGE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2FLAST_CHANGE?alt=media"
 
-REVISION=$(curl -s -S $LASTCHANGE_URL)
+if [ -z "$REVISION" ]; then
+ REVISION=$(curl -s -S $LASTCHANGE_URL)
 
-echo "latest revision is $REVISION"
+  echo "latest revision is $REVISION"
+else
+  echo "Using given revision $REVISION as latest revision"
+fi
 
 if [ -d $REVISION ] ; then
   echo "already have latest version"


### PR DESCRIPTION
In some cases a fixed revision of chromium is preferred, e.g. for building docker images.