### PR TITLE
Add platform option to enable mac use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # chromium-latest-linux
-Scripts to download and run the latest Linux build of Chromium.
+Scripts to download and run the latest **Mac or Linux** build of Chromium.
+
+## Usage
+```console
+./update.sh                   # Update linux version
+./update.sh mac               # Update mac version
+
+./update-and-run.sh           # Update and run latest linux version
+./update-and-run.sh mac       # Update and run latest mac version
+./update-and-run.sh linux     # You can also specify linux for clarity
+```

--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 cd $(dirname $0)
-./update.sh && ./run.sh
+./update.sh $1 && ./run.sh

--- a/update.sh
+++ b/update.sh
@@ -3,17 +3,13 @@
 cd $(dirname $0)
 
 case "$1" in
-  linux)
-    PLATFORM="linux"
-    REVISION_PREFIX="Linux_x64"
-    ;;
   mac)
     PLATFORM="mac"
     REVISION_PREFIX="Mac"
     ;;
-  *)
-    echo "Please specify platform (mac or linux) as argument.";
-    exit 1
+  linux | *)
+    PLATFORM="linux"
+    REVISION_PREFIX="Linux_x64"
     ;;
 esac
 

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,22 @@
 
 cd $(dirname $0)
 
-LASTCHANGE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2FLAST_CHANGE?alt=media"
+case "$1" in
+  linux)
+    PLATFORM="linux"
+    REVISION_PREFIX="Linux_x64"
+    ;;
+  mac)
+    PLATFORM="mac"
+    REVISION_PREFIX="Mac"
+    ;;
+  *)
+    echo "Please specify platform (mac or linux) as argument.";
+    exit 1
+    ;;
+esac
+
+LASTCHANGE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/${REVISION_PREFIX}%2FLAST_CHANGE?alt=media"
 
 REVISION=$(curl -s -S $LASTCHANGE_URL)
 
@@ -13,9 +28,9 @@ if [ -d $REVISION ] ; then
   exit
 fi
 
-ZIP_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F$REVISION%2Fchrome-linux.zip?alt=media"
+ZIP_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/${REVISION_PREFIX}%2F${REVISION}%2Fchrome-${PLATFORM}.zip?alt=media"
 
-ZIP_FILE="${REVISION}-chrome-linux.zip"
+ZIP_FILE="${REVISION}-chrome-${PLATFORM}.zip"
 
 echo "fetching $ZIP_URL"
 
@@ -27,5 +42,5 @@ echo "unzipping.."
 unzip $ZIP_FILE
 popd
 rm -f ./latest
-ln -s $REVISION/chrome-linux/ ./latest
+ln -s $REVISION/chrome-$PLATFORM/ ./latest
 


### PR DESCRIPTION
Add platform option to `update.sh`. This allows downloading the latest Chromium version for mac OS too.

Examples:
```
./update.sh mac
./update.sh linux
./update.sh           # defaults to linux
```
