### PR TITLE
Improvements to scripts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
-#! /bin/bash
+#!/bin/sh
 
-BASEDIR=$(dirname $0)
+BASEDIR="$(dirname $(realpath $(readlink -f $0)))"
 
 $BASEDIR/latest/chrome --user-data-dir="$BASEDIR/user-data-dir" $* &> /dev/null &

--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -1,3 +1,5 @@
-#! /bin/bash
-cd $(dirname $0)
-./update.sh && ./run.sh
+#!/bin/sh
+
+BASEDIR="$(dirname $(realpath $(readlink -f $0)))"
+
+$BASEDIR/update.sh && $BASEDIR/run.sh

--- a/update.sh
+++ b/update.sh
@@ -26,7 +26,7 @@ case $(web) in
 esac
 }
 
-TRUNK="continuous"
+TRUNK="snapshots"
 if [ -n "$1" ]; then
 OPT="$1"
 shift

--- a/update.sh
+++ b/update.sh
@@ -36,7 +36,7 @@ case "$OPT" in
 esac
 fi
 
-LASTCHANGE_URL="https://commondatastorage.googleapis.com/chromium-browser-$TRUNK/Linux/LAST_CHANGE"
+LASTCHANGE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-$TRUNK/o/Linux_x64%2FLAST_CHANGE?alt=media"
 
 REVISION=$(out $LASTCHANGE_URL)
 


### PR DESCRIPTION
1. URLs were updated.
2. Parse an argument to select **continuous** builds instead of **snapshots**.
3. Use `$BASEDIR` variable instead of using `cd` command.
4. Works with either `wget` or `curl` installed.